### PR TITLE
Improvements in batchsize for log cleaning, index on created_at, avoiding extra db update call.

### DIFF
--- a/Model/Clean.php
+++ b/Model/Clean.php
@@ -71,7 +71,7 @@ class Clean
         $collection = $this->logCollectionFactory->create();
         $collection = $collection->addFieldToSelect(LogResourceModel::LOG_ID)
                                  ->addFieldToFilter(LogResourceModel::CREATED_AT, ['lt' => $datetime])
-                                 ->setPageSize(2);
+                                 ->setPageSize(1000);
 
         $pageCount = $collection->getLastPageNumber();
         $currentPage = 1;

--- a/Model/LogHandle.php
+++ b/Model/LogHandle.php
@@ -78,27 +78,22 @@ class LogHandle
         string $requestBody,
         string $requestDateTime
     ) {
-        try {
-            if ($this->config->isSecretMode()) {
-                $requestorIp = $this->secretParser->parseIp();
-                $requestHeaders = $this->secretParser->parseHeades($requestHeaders);
-                $requestBody = $this->secretParser->parseBody($requestBody);
-            }
-
-            $log = $this->logFactory->create();
-            $log->setData([
-                'request_method' => $requestMethod,
-                'requestor_ip' => $requestorIp,
-                'request_url' => $requestPath,
-                'request_headers' => $requestHeaders,
-                'request_body' => $requestBody,
-                'request_datetime' => $requestDateTime
-            ]);
-            $this->logResourceModel->save($log);
-            $this->lastLog = $log;
-        } catch (Exception $exception) {
-            $this->logger->error(__('Cant complete webapi log save because of error: %1', $exception->getMessage()));
+        if ($this->config->isSecretMode()) {
+            $requestorIp = $this->secretParser->parseIp();
+            $requestHeaders = $this->secretParser->parseHeades($requestHeaders);
+            $requestBody = $this->secretParser->parseBody($requestBody);
         }
+
+        $log = $this->logFactory->create();
+        $log->setData([
+            'request_method' => $requestMethod,
+            'requestor_ip' => $requestorIp,
+            'request_url' => $requestPath,
+            'request_headers' => $requestHeaders,
+            'request_body' => $requestBody,
+            'request_datetime' => $requestDateTime
+        ]);
+        $this->lastLog = $log;
     }
 
     /**

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -24,5 +24,8 @@
         <index referenceId="WEBAPILOGS_ENTITY_ID_ENTITY_ID" indexType="btree">
             <column name="log_id"/>
         </index>
+        <index referenceId="WEBAPILOGS_CREATED_AT_CREATED_AT" indexType="btree">
+            <column name="created_at"/>
+        </index>
     </table>
 </schema>


### PR DESCRIPTION
- created_at index created since it is called for log cleaning and can take long depending on the log table size.
- Added a default batch_size that is a bit saner then 2.
- Avoiding an extra database update call in the before plugin.